### PR TITLE
US-11: validate provider capabilities before startup

### DIFF
--- a/ManufacturingOptimization.Common.Messaging/Abstractions/IMessagingInfrastructure.cs
+++ b/ManufacturingOptimization.Common.Messaging/Abstractions/IMessagingInfrastructure.cs
@@ -5,4 +5,5 @@ public interface IMessagingInfrastructure
     void DeclareExchange(string exchangeName, string exchangeType = "topic");
     void DeclareQueue(string queueName);
     void BindQueue(string queueName, string exchangeName, string routingKey);
+    void PurgeQueue(string queueName);
 }

--- a/ManufacturingOptimization.Common.Messaging/Messages/ProviderManagement/ValidateProviderCapabilityCommand.cs
+++ b/ManufacturingOptimization.Common.Messaging/Messages/ProviderManagement/ValidateProviderCapabilityCommand.cs
@@ -1,0 +1,25 @@
+using ManufacturingOptimization.Common.Messaging.Abstractions;
+
+namespace ManufacturingOptimization.Common.Messaging.Messages.ProviderManagement;
+
+/// <summary>
+/// Command to validate provider capabilities before registration/startup.
+/// Published by ProviderRegistry, consumed by Engine.
+/// </summary>
+public class ValidateProviderCapabilityCommand : IMessage, ICommand
+{
+    public Guid CommandId { get; set; } = Guid.NewGuid();
+    public Guid ProviderId { get; set; }
+    public string ProviderType { get; set; } = string.Empty;
+    public string ProviderName { get; set; } = string.Empty;
+    public List<string> Capabilities { get; set; } = new();
+    public TechnicalRequirementsDto TechnicalRequirements { get; set; } = new();
+    public Guid CorrelationId { get; set; } = Guid.NewGuid();
+}
+
+public class TechnicalRequirementsDto
+{
+    public double AxisHeight { get; set; }
+    public double Power { get; set; }
+    public double Tolerance { get; set; }
+}

--- a/ManufacturingOptimization.Common.Messaging/Messages/ProviderManagment/ProviderCapabilityValidationApprovedEvent.cs
+++ b/ManufacturingOptimization.Common.Messaging/Messages/ProviderManagment/ProviderCapabilityValidationApprovedEvent.cs
@@ -1,0 +1,16 @@
+using ManufacturingOptimization.Common.Messaging.Abstractions;
+
+namespace ManufacturingOptimization.Common.Messaging.Messages.ProviderManagment;
+
+/// <summary>
+/// Event indicating provider capability validation was approved.
+/// Published by Engine, consumed by ProviderRegistry.
+/// </summary>
+public class ProviderCapabilityValidationApprovedEvent : IMessage, IEvent
+{
+    public Guid CommandId { get; set; }
+    public Guid ProviderId { get; set; }
+    public string ProviderType { get; set; } = string.Empty;
+    public string ProviderName { get; set; } = string.Empty;
+    public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+}

--- a/ManufacturingOptimization.Common.Messaging/Messages/ProviderManagment/ProviderCapabilityValidationDeclinedEvent.cs
+++ b/ManufacturingOptimization.Common.Messaging/Messages/ProviderManagment/ProviderCapabilityValidationDeclinedEvent.cs
@@ -1,0 +1,17 @@
+using ManufacturingOptimization.Common.Messaging.Abstractions;
+
+namespace ManufacturingOptimization.Common.Messaging.Messages.ProviderManagment;
+
+/// <summary>
+/// Event indicating provider capability validation was declined.
+/// Published by Engine, consumed by ProviderRegistry.
+/// </summary>
+public class ProviderCapabilityValidationDeclinedEvent : IMessage, IEvent
+{
+    public Guid CommandId { get; set; }
+    public Guid ProviderId { get; set; }
+    public string ProviderType { get; set; } = string.Empty;
+    public string ProviderName { get; set; } = string.Empty;
+    public string Reason { get; set; } = string.Empty;
+    public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+}

--- a/ManufacturingOptimization.Common.Messaging/Messages/ProviderManagment/ValidateProviderCapabilityCommand.cs
+++ b/ManufacturingOptimization.Common.Messaging/Messages/ProviderManagment/ValidateProviderCapabilityCommand.cs
@@ -1,0 +1,24 @@
+using ManufacturingOptimization.Common.Messaging.Abstractions;
+
+namespace ManufacturingOptimization.Common.Messaging.Messages.ProviderManagment;
+
+/// <summary>
+/// Command to validate provider capabilities before registration/startup.
+/// Published by ProviderRegistry, consumed by Engine.
+/// </summary>
+public class ValidateProviderCapabilityCommand : IMessage, ICommand
+{
+    public Guid CommandId { get; set; } = Guid.NewGuid();
+    public Guid ProviderId { get; set; }
+    public string ProviderType { get; set; } = string.Empty;
+    public string ProviderName { get; set; } = string.Empty;
+    public List<string> Capabilities { get; set; } = new();
+    public TechnicalRequirementsDto TechnicalRequirements { get; set; } = new();
+}
+
+public class TechnicalRequirementsDto
+{
+    public double AxisHeight { get; set; }
+    public double Power { get; set; }
+    public double Tolerance { get; set; }
+}

--- a/ManufacturingOptimization.Common.Messaging/Messages/ProviderRoutingKeys.cs
+++ b/ManufacturingOptimization.Common.Messaging/Messages/ProviderRoutingKeys.cs
@@ -5,4 +5,9 @@ public static class ProviderRoutingKeys
     public const string StartAll = "provider.start-all";
     public const string Registered = "provider.registered";
     public const string AllReady = "provider.all-ready";
+    
+    // Provider validation flow (US-11)
+    public const string ValidationRequested = "provider.validation.requested";
+    public const string ValidationApproved = "provider.validation.approved";
+    public const string ValidationDeclined = "provider.validation.declined";
 }

--- a/ManufacturingOptimization.Common.Messaging/RabbitMqService.cs
+++ b/ManufacturingOptimization.Common.Messaging/RabbitMqService.cs
@@ -13,6 +13,7 @@ public class RabbitMqService : IMessagePublisher, IMessageSubscriber, IMessaging
     private readonly IConnection _connection;
     private readonly IModel _channel;
     private readonly ILogger<RabbitMqService> _logger;
+    private readonly Dictionary<string, EventingBasicConsumer> _consumers = new();
 
     public RabbitMqService(IOptions<RabbitMqSettings> config, ILogger<RabbitMqService> logger)
     {
@@ -46,44 +47,73 @@ public class RabbitMqService : IMessagePublisher, IMessageSubscriber, IMessaging
         _channel.QueueBind(queue: queueName, exchange: exchangeName, routingKey: routingKey);
     }
 
+    public void PurgeQueue(string queueName)
+    {
+        _channel.QueuePurge(queueName);
+    }
+
     public void Publish<T>(string exchangeName, string routingKey, T message) where T : IMessage
     {
         var json = JsonSerializer.Serialize(message);
         var body = Encoding.UTF8.GetBytes(json);
 
+        var properties = _channel.CreateBasicProperties();
+        properties.Headers = new Dictionary<string, object>
+        {
+            ["MessageType"] = typeof(T).FullName ?? typeof(T).Name
+        };
+
         _channel.BasicPublish(
             exchange: exchangeName,
             routingKey: routingKey,
-            basicProperties: null,
+            basicProperties: properties,
             body: body);
     }
 
     public void Subscribe<T>(string queueName, Action<T> handler) where T : IMessage
     {
-        var consumer = new EventingBasicConsumer(_channel);
-
-        consumer.Received += (model, e) =>
+        // Reuse existing consumer if queue already has one, otherwise create new
+        if (!_consumers.TryGetValue(queueName, out var consumer))
         {
-            try
-            {
-                var body = e.Body.ToArray();
-                var json = Encoding.UTF8.GetString(body);
-                var message = JsonSerializer.Deserialize<T>(json);
+            consumer = new EventingBasicConsumer(_channel);
+            _consumers[queueName] = consumer;
 
-                if (message != null)
+            consumer.Received += (model, e) =>
+            {
+                try
                 {
-                    handler(message);
+                    var body = e.Body.ToArray();
+                    var json = Encoding.UTF8.GetString(body);
+                    
+                    // Try to get message type from header
+                    string? messageType = null;
+                    if (e.BasicProperties?.Headers?.TryGetValue("MessageType", out var typeObj) == true)
+                    {
+                        messageType = Encoding.UTF8.GetString((byte[])typeObj);
+                    }
+
+                    // Try to deserialize and invoke matching handler
+                    var typeName = typeof(T).FullName ?? typeof(T).Name;
+                    if (messageType == null || messageType == typeName)
+                    {
+                        var message = JsonSerializer.Deserialize<T>(json);
+                        if (message != null)
+                        {
+                            handler(message);
+                        }
+                    }
+
+                    _channel.BasicAck(deliveryTag: e.DeliveryTag, multiple: false);
                 }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error processing message from queue {Queue}", queueName);
+                    _channel.BasicNack(deliveryTag: e.DeliveryTag, multiple: false, requeue: false);
+                }
+            };
 
-                _channel.BasicAck(deliveryTag: e.DeliveryTag, multiple: false);
-            }
-            catch (Exception ex)
-            {
-                _channel.BasicNack(deliveryTag: e.DeliveryTag, multiple: false, requeue: false);
-            }
-        };
-
-        _channel.BasicConsume(queue: queueName, autoAck: false, consumer: consumer);
+            _channel.BasicConsume(queue: queueName, autoAck: false, consumer: consumer);
+        }
     }
 
     public void Dispose()

--- a/ManufacturingOptimization.Engine/Program.cs
+++ b/ManufacturingOptimization.Engine/Program.cs
@@ -3,12 +3,14 @@ using ManufacturingOptimization.Common.Messaging.Abstractions;
 using ManufacturingOptimization.Engine;
 using ManufacturingOptimization.Engine.Abstractions;
 using ManufacturingOptimization.Engine.Services;
+using ManufacturingOptimization.Engine.Settings;
 using Microsoft.Extensions.Options;
 
 var builder = Host.CreateApplicationBuilder(args);
 
 // Configure RabbitMQ
 builder.Services.Configure<RabbitMqSettings>(builder.Configuration.GetSection(RabbitMqSettings.SectionName));
+builder.Services.Configure<ProviderValidationSettings>(builder.Configuration.GetSection(ProviderValidationSettings.SectionName));
 
 builder.Services.AddSingleton<RabbitMqService>();
 builder.Services.AddSingleton<IMessagePublisher>(sp => sp.GetRequiredService<RabbitMqService>());
@@ -18,6 +20,7 @@ builder.Services.AddSingleton<IMessagingInfrastructure>(sp => sp.GetRequiredServ
 // Provider registry
 builder.Services.AddSingleton<IProviderRepository, InMemoryProviderRepository>();
 
+builder.Services.AddHostedService<ProviderCapabilityValidationService>();
 builder.Services.AddHostedService<EngineWorker>();
 
 var host = builder.Build();

--- a/ManufacturingOptimization.Engine/Services/InMemoryProviderRepository.cs
+++ b/ManufacturingOptimization.Engine/Services/InMemoryProviderRepository.cs
@@ -8,6 +8,8 @@ public class InMemoryProviderRepository : IProviderRepository
     private readonly ConcurrentDictionary<Guid, RegisteredProvider> _providers = new();
     private readonly ILogger<InMemoryProviderRepository> _logger;
 
+    public int Count => _providers.Count;
+
     public InMemoryProviderRepository(ILogger<InMemoryProviderRepository> logger)
     {
         _logger = logger;
@@ -29,6 +31,4 @@ public class InMemoryProviderRepository : IProviderRepository
     {
         return _providers.Values.ToList();
     }
-
-    public int Count => _providers.Count;
 }

--- a/ManufacturingOptimization.Engine/Services/ProviderCapabilityValidationService.cs
+++ b/ManufacturingOptimization.Engine/Services/ProviderCapabilityValidationService.cs
@@ -1,0 +1,230 @@
+using ManufacturingOptimization.Common.Messaging.Abstractions;
+using ManufacturingOptimization.Common.Messaging.Messages;
+using ManufacturingOptimization.Common.Messaging.Messages.ProviderManagment;
+using ManufacturingOptimization.Engine.Abstractions;
+using ManufacturingOptimization.Engine.Settings;
+using Microsoft.Extensions.Options;
+
+namespace ManufacturingOptimization.Engine.Services;
+
+/// <summary>
+/// Handles provider validation requests from ProviderRegistry.
+/// </summary>
+public class ProviderCapabilityValidationService : BackgroundService
+{
+    private readonly ILogger<ProviderCapabilityValidationService> _logger;
+    private readonly IMessageSubscriber _subscriber;
+    private readonly IMessagePublisher _publisher;
+    private readonly IMessagingInfrastructure _messagingInfrastructure;
+    private readonly ProviderValidationSettings _settings;
+
+    public ProviderCapabilityValidationService(
+        ILogger<ProviderCapabilityValidationService> logger,
+        IMessageSubscriber subscriber,
+        IMessagePublisher publisher,
+        IMessagingInfrastructure messagingInfrastructure,
+        IProviderRepository providerRepository,
+        IOptions<ProviderValidationSettings> settings)
+    {
+        _logger = logger;
+        _subscriber = subscriber;
+        _publisher = publisher;
+        _messagingInfrastructure = messagingInfrastructure;
+        _settings = settings.Value;
+
+        // Setup RabbitMQ immediately in constructor to ensure queues are purged
+        // and handlers are ready before any validation requests are sent
+        SetupRabbitMq();
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await Task.Delay(Timeout.Infinite, stoppingToken);
+    }
+
+    private void SetupRabbitMq()
+    {
+        _messagingInfrastructure.DeclareQueue("engine.provider.validation");
+        
+        // Clear any stale validation requests from previous runs
+        _messagingInfrastructure.PurgeQueue("engine.provider.validation");
+        
+        _messagingInfrastructure.BindQueue("engine.provider.validation", Exchanges.Provider, ProviderRoutingKeys.ValidationRequested);
+        
+        _subscriber.Subscribe<ValidateProviderCapabilityCommand>("engine.provider.validation", HandleValidationRequest);
+    }
+
+    private void HandleValidationRequest(ValidateProviderCapabilityCommand request)
+    {
+        try
+        {
+            var validationResult = ValidateProvider(request);
+
+            if (validationResult.IsValid)
+            {
+                var approvedResponse = new ProviderCapabilityValidationApprovedEvent
+                {
+                    CommandId = request.CommandId,
+                    ProviderId = request.ProviderId,
+                    ProviderType = request.ProviderType,
+                    ProviderName = request.ProviderName
+                };
+
+                _publisher.Publish(Exchanges.Provider, ProviderRoutingKeys.ValidationApproved, approvedResponse);
+            }
+            else
+            {
+                var declinedResponse = new ProviderCapabilityValidationDeclinedEvent
+                {
+                    CommandId = request.CommandId,
+                    ProviderId = request.ProviderId,
+                    ProviderType = request.ProviderType,
+                    ProviderName = request.ProviderName,
+                    Reason = validationResult.Reason
+                };
+
+                _publisher.Publish(Exchanges.Provider, ProviderRoutingKeys.ValidationDeclined, declinedResponse);
+            }
+        }
+        catch (Exception ex)
+        {
+            var errorResponse = new ProviderCapabilityValidationDeclinedEvent
+            {
+                CommandId = request.CommandId,
+                ProviderId = request.ProviderId,
+                ProviderType = request.ProviderType,
+                ProviderName = request.ProviderName,
+                Reason = $"Internal error: {ex.Message}"
+            };
+
+            _publisher.Publish(Exchanges.Provider, ProviderRoutingKeys.ValidationDeclined, errorResponse);
+        }
+    }
+
+    private ValidationResult ValidateProvider(ValidateProviderCapabilityCommand request)
+    {
+        // Validate capabilities
+        var capabilitiesResult = ValidateCapabilities(request.ProviderType, request.Capabilities);
+        if (!capabilitiesResult.IsValid)
+        {
+            return capabilitiesResult;
+        }
+
+        // Validate technical requirements
+        var technicalResult = ValidateTechnicalRequirements(request.TechnicalRequirements);
+        if (!technicalResult.IsValid)
+        {
+            return technicalResult;
+        }
+
+        return new ValidationResult { IsValid = true };
+    }
+
+    private ValidationResult ValidateCapabilities(string providerType, List<string>? capabilities)
+    {
+        var expectedCapabilities = providerType switch
+        {
+            "MainRemanufacturingCenter" => _settings.RequiredCapabilities.MainRemanufacturingCenter,
+            "EngineeringDesignFirm" => _settings.RequiredCapabilities.EngineeringDesignFirm,
+            "PrecisionMachineShop" => _settings.RequiredCapabilities.PrecisionMachineShop,
+            _ => null
+        };
+
+        if (expectedCapabilities == null)
+        {
+            return new ValidationResult
+            {
+                IsValid = false,
+                Reason = $"Unknown provider type: {providerType}"
+            };
+        }
+
+        if (capabilities == null || capabilities.Count == 0)
+        {
+            return new ValidationResult
+            {
+                IsValid = false,
+                Reason = "No capabilities provided"
+            };
+        }
+
+        var missingCapabilities = expectedCapabilities.Except(capabilities).ToList();
+        if (missingCapabilities.Any())
+        {
+            return new ValidationResult
+            {
+                IsValid = false,
+                Reason = $"Missing required capabilities: {string.Join(", ", missingCapabilities)}"
+            };
+        }
+
+        var unexpectedCapabilities = capabilities.Except(expectedCapabilities).ToList();
+        if (unexpectedCapabilities.Any())
+        {
+            return new ValidationResult
+            {
+                IsValid = false,
+                Reason = $"Unexpected capabilities: {string.Join(", ", unexpectedCapabilities)}"
+            };
+        }
+
+        return new ValidationResult { IsValid = true };
+    }
+
+    private ValidationResult ValidateTechnicalRequirements(TechnicalRequirementsDto? requirements)
+    {
+        if (requirements == null)
+        {
+            return new ValidationResult { IsValid = true }; // Optional
+        }
+
+        var limits = _settings.TechnicalLimits;
+
+        // Validate AxisHeight
+        if (requirements.AxisHeight > 0)
+        {
+            if (requirements.AxisHeight < limits.MinAxisHeight || requirements.AxisHeight > limits.MaxAxisHeight)
+            {
+                return new ValidationResult
+                {
+                    IsValid = false,
+                    Reason = $"AxisHeight {requirements.AxisHeight} out of range [{limits.MinAxisHeight}-{limits.MaxAxisHeight}]"
+                };
+            }
+        }
+
+        // Validate Power
+        if (requirements.Power > 0)
+        {
+            if (requirements.Power < limits.MinPower || requirements.Power > limits.MaxPower)
+            {
+                return new ValidationResult
+                {
+                    IsValid = false,
+                    Reason = $"Power {requirements.Power} out of range [{limits.MinPower}-{limits.MaxPower}]"
+                };
+            }
+        }
+
+        // Validate Tolerance
+        if (requirements.Tolerance > 0)
+        {
+            if (requirements.Tolerance < limits.MinTolerance || requirements.Tolerance > limits.MaxTolerance)
+            {
+                return new ValidationResult
+                {
+                    IsValid = false,
+                    Reason = $"Tolerance {requirements.Tolerance} out of range [{limits.MinTolerance}-{limits.MaxTolerance}]"
+                };
+            }
+        }
+
+        return new ValidationResult { IsValid = true };
+    }
+
+    private class ValidationResult
+    {
+        public bool IsValid { get; set; }
+        public string Reason { get; set; } = string.Empty;
+    }
+}

--- a/ManufacturingOptimization.Engine/Settings/ProviderValidationSettings.cs
+++ b/ManufacturingOptimization.Engine/Settings/ProviderValidationSettings.cs
@@ -1,0 +1,27 @@
+namespace ManufacturingOptimization.Engine.Settings;
+
+public class ProviderValidationSettings
+{
+    public const string SectionName = "ProviderValidation";
+
+    public TechnicalLimits TechnicalLimits { get; set; } = new();
+    public RequiredCapabilities RequiredCapabilities { get; set; } = new();
+    public List<string> RequiredProcesses { get; set; } = new();
+}
+
+public class TechnicalLimits
+{
+    public double MinAxisHeight { get; set; }
+    public double MaxAxisHeight { get; set; }
+    public double MinPower { get; set; }
+    public double MaxPower { get; set; }
+    public double MinTolerance { get; set; }
+    public double MaxTolerance { get; set; }
+}
+
+public class RequiredCapabilities
+{
+    public List<string> MainRemanufacturingCenter { get; set; } = new();
+    public List<string> EngineeringDesignFirm { get; set; } = new();
+    public List<string> PrecisionMachineShop { get; set; } = new();
+}

--- a/ManufacturingOptimization.Engine/appsettings.json
+++ b/ManufacturingOptimization.Engine/appsettings.json
@@ -4,5 +4,20 @@
       "Default": "Information",
       "Microsoft.Hosting.Lifetime": "Information"
     }
+  },
+  "ProviderValidation": {
+    "TechnicalLimits": {
+      "MinAxisHeight": 100,
+      "MaxAxisHeight": 1000,
+      "MinPower": 500,
+      "MaxPower": 5000,
+      "MinTolerance": 0.001,
+      "MaxTolerance": 0.1
+    },
+    "RequiredCapabilities": {
+      "MainRemanufacturingCenter": [ "Cleaning", "Disassembly", "PartSubstitution", "Reassembly", "Certification" ],
+      "EngineeringDesignFirm": [ "Redesign" ],
+      "PrecisionMachineShop": [ "Turning", "Grinding" ]
+    }
   }
 }

--- a/ManufacturingOptimization.ProviderRegistry/Abstractions/IProviderRepository.cs
+++ b/ManufacturingOptimization.ProviderRegistry/Abstractions/IProviderRepository.cs
@@ -5,4 +5,5 @@ namespace ManufacturingOptimization.ProviderRegistry.Abstractions;
 public interface IProviderRepository
 {
     Task<IEnumerable<Provider>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task<Provider?> GetByIdAsync(Guid providerId, CancellationToken cancellationToken = default);
 }

--- a/ManufacturingOptimization.ProviderRegistry/Entities/Provider.cs
+++ b/ManufacturingOptimization.ProviderRegistry/Entities/Provider.cs
@@ -6,4 +6,13 @@ public class Provider
     public string Type { get; set; } = string.Empty;
     public string Name { get; set; } = string.Empty;
     public bool Enabled { get; set; } = true;
+    public List<string> Capabilities { get; set; } = new();
+    public TechnicalRequirements TechnicalRequirements { get; set; } = new();
+}
+
+public class TechnicalRequirements
+{
+    public double AxisHeight { get; set; }
+    public double Power { get; set; }
+    public double Tolerance { get; set; }
 }

--- a/ManufacturingOptimization.ProviderRegistry/Program.cs
+++ b/ManufacturingOptimization.ProviderRegistry/Program.cs
@@ -24,6 +24,10 @@ builder.Services.AddSingleton<IMessagingInfrastructure>(sp => sp.GetRequiredServ
 // Provider orchestration services
 builder.Services.AddSingleton<IProviderRepository, JsonProviderRepository>();
 
+// Provider validation coordination (US-11)
+builder.Services.AddSingleton<ProviderСapabilityValidationService>();
+builder.Services.AddHostedService(sp => sp.GetRequiredService<ProviderСapabilityValidationService>());
+
 // Register appropriate orchestrator based on mode
 var orchestrationMode = builder.Configuration["Orchestration:Mode"] ?? "Production";
 if (orchestrationMode == "Production")

--- a/ManufacturingOptimization.ProviderRegistry/Services/JsonProviderRepository.cs
+++ b/ManufacturingOptimization.ProviderRegistry/Services/JsonProviderRepository.cs
@@ -44,6 +44,12 @@ public class JsonProviderRepository : IProviderRepository
         }
     }
 
+    public async Task<Provider?> GetByIdAsync(Guid providerId, CancellationToken cancellationToken = default)
+    {
+        var providers = await GetAllAsync(cancellationToken);
+        return providers.FirstOrDefault(p => p.Id == providerId);
+    }
+
     private class ProvidersConfig
     {
         public Provider[] Providers { get; set; } = Array.Empty<Provider>();

--- a/ManufacturingOptimization.ProviderRegistry/Services/ProviderСapabilityValidationService.cs
+++ b/ManufacturingOptimization.ProviderRegistry/Services/ProviderСapabilityValidationService.cs
@@ -1,0 +1,181 @@
+using ManufacturingOptimization.Common.Messaging.Abstractions;
+using ManufacturingOptimization.Common.Messaging.Messages;
+using ManufacturingOptimization.Common.Messaging.Messages.ProviderManagment;
+using ManufacturingOptimization.ProviderRegistry.Abstractions;
+using ManufacturingOptimization.ProviderRegistry.Entities;
+using System.Collections.Concurrent;
+
+namespace ManufacturingOptimization.ProviderRegistry.Services;
+    
+/// <summary>
+/// Coordinates provider validation process.
+/// Tracks validation requests/responses and publishes AllProvidersReady when done.
+/// </summary>
+public class ProviderСapabilityValidationService : BackgroundService
+{
+    private readonly ILogger<ProviderСapabilityValidationService> _logger;
+    private readonly IMessagePublisher _publisher;
+    private readonly IMessageSubscriber _subscriber;
+    private readonly IMessagingInfrastructure _messagingInfrastructure;
+    private readonly IProviderOrchestrator _orchestrator;
+    private readonly IProviderRepository _repository;
+    
+    private readonly ConcurrentDictionary<Guid, ProviderValidationState> _validations = new();
+
+    public ProviderСapabilityValidationService(
+        ILogger<ProviderСapabilityValidationService> logger,
+        IMessagePublisher publisher,
+        IMessageSubscriber subscriber,
+        IMessagingInfrastructure messagingInfrastructure,
+        IProviderOrchestrator orchestrator,
+        IProviderRepository repository)
+    {
+        _logger = logger;
+        _publisher = publisher;
+        _subscriber = subscriber;
+        _messagingInfrastructure = messagingInfrastructure;
+        _orchestrator = orchestrator;
+        _repository = repository;
+
+        // Setup RabbitMQ subscriptions immediately in constructor
+        // This ensures handlers are ready before any validation requests are sent
+        SetupRabbitMq();
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await Task.Delay(Timeout.Infinite, stoppingToken);
+    }
+
+    private void SetupRabbitMq()
+    {
+        // Single queue for both approved and declined responses
+        _messagingInfrastructure.DeclareQueue("provider.validation.responses");
+        
+        // Clear any stale messages from previous runs
+        _messagingInfrastructure.PurgeQueue("provider.validation.responses");
+        
+        _messagingInfrastructure.BindQueue("provider.validation.responses", Exchanges.Provider, ProviderRoutingKeys.ValidationApproved);
+        _messagingInfrastructure.BindQueue("provider.validation.responses", Exchanges.Provider, ProviderRoutingKeys.ValidationDeclined);
+        
+        _subscriber.Subscribe<ProviderCapabilityValidationApprovedEvent>("provider.validation.responses", async response => await HandleValidationApprovedAsync(response));
+        _subscriber.Subscribe<ProviderCapabilityValidationDeclinedEvent>("provider.validation.responses", HandleValidationDeclined);
+    }
+
+    public async Task StartValidationForAllProvidersAsync()
+    {
+        var providers = await _repository.GetAllAsync();
+
+        if (!providers.Any())
+        {
+            _publisher.Publish(Exchanges.Provider, ProviderRoutingKeys.AllReady, new AllProvidersReadyEvent());
+            return;
+        }
+
+        // Register all providers in pending validations first
+        foreach (var provider in providers)
+        {
+            if (!provider.Enabled)
+            {
+                continue;
+            }
+
+            var state = new ProviderValidationState
+            {
+                Provider = provider,
+                RequestedAt = DateTime.UtcNow,
+                Status = ValidationStatus.Pending
+            };
+
+            _validations[provider.Id] = state;
+        }
+
+        // Send validation requests for all
+        foreach (var state in _validations.Values)
+        {
+            var validationRequest = new ValidateProviderCapabilityCommand
+            {
+                ProviderId = state.Provider.Id,
+                ProviderType = state.Provider.Type,
+                ProviderName = state.Provider.Name,
+                Capabilities = state.Provider.Capabilities,
+                TechnicalRequirements = new TechnicalRequirementsDto
+                {
+                    AxisHeight = state.Provider.TechnicalRequirements.AxisHeight,
+                    Power = state.Provider.TechnicalRequirements.Power,
+                    Tolerance = state.Provider.TechnicalRequirements.Tolerance
+                },
+            };
+
+            _publisher.Publish(Exchanges.Provider, ProviderRoutingKeys.ValidationRequested, validationRequest);
+        }
+    }
+
+    private async Task HandleValidationApprovedAsync(ProviderCapabilityValidationApprovedEvent response)
+    {
+        if (!_validations.TryGetValue(response.ProviderId, out var state))
+        {
+            return;
+        }
+
+        state.Status = ValidationStatus.Approved;
+        state.RespondedAt = DateTime.UtcNow;
+
+        try
+        {
+            await _orchestrator.StartAsync(state.Provider);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to start provider {ProviderId}", response.ProviderId);
+        }
+
+        CheckIfAllValidationsComplete();
+    }
+
+    private void HandleValidationDeclined(ProviderCapabilityValidationDeclinedEvent response)
+    {
+        if (!_validations.TryGetValue(response.ProviderId, out var state))
+        {
+            return;
+        }
+
+        state.Status = ValidationStatus.Declined;
+        state.RespondedAt = DateTime.UtcNow;
+
+        _logger.LogWarning("Provider {ProviderId} ({ProviderType}) validation Declined: {Reason}", 
+            response.ProviderId, response.ProviderType, response.Reason);
+
+        CheckIfAllValidationsComplete();
+    }
+
+    private void CheckIfAllValidationsComplete()
+    {
+        if (_validations.IsEmpty)
+        {
+            return;
+        }
+
+        var allResponded = _validations.Values.All(v => v.Status != ValidationStatus.Pending);
+
+        if (allResponded)
+        {
+            _publisher.Publish(Exchanges.Provider, ProviderRoutingKeys.AllReady, new AllProvidersReadyEvent());
+        }
+    }
+
+    private enum ValidationStatus
+    {
+        Pending,
+        Approved,
+        Declined
+    }
+
+    private class ProviderValidationState
+    {
+        public Provider Provider { get; set; } = null!;
+        public DateTime RequestedAt { get; set; }
+        public DateTime? RespondedAt { get; set; }
+        public ValidationStatus Status { get; set; }
+    }
+}

--- a/ManufacturingOptimization.ProviderRegistry/providers.json
+++ b/ManufacturingOptimization.ProviderRegistry/providers.json
@@ -4,19 +4,48 @@
       "id": "f93a2956-e430-4b50-b688-991b5c33f5f4",
       "type": "MainRemanufacturingCenter",
       "name": "Main Remanufacturing Center",
-      "enabled": true
+      "enabled": true,
+      "capabilities": [
+        "Cleaning",
+        "Disassembly",
+        "PartSubstitution",
+        "Reassembly",
+        "Certification"
+      ],
+      "technicalRequirements": {
+        "axisHeight": 500.0,
+        "power": 1500.0,
+        "tolerance": 0.01
+      }
     },
     {
       "id": "f8127a26-e818-4d27-8812-10d422c45a6c",
       "type": "EngineeringDesignFirm",
       "name": "Engineering Design Firm",
-      "enabled": true
+      "enabled": true,
+      "capabilities": [
+        "Redesign"
+      ],
+      "technicalRequirements": {
+        "axisHeight": 0.0,
+        "power": 0.0,
+        "tolerance": 0.001
+      }
     },
     {
       "id": "70564b7f-d634-4a90-b3f9-33224915dbc4",
       "type": "PrecisionMachineShop",
       "name": "Precision Machine Shop",
-      "enabled": true
+      "enabled": true,
+      "capabilities": [
+        "Turning",
+        "Grinding"
+      ],
+      "technicalRequirements": {
+        "axisHeight": 300.0,
+        "power": 2000.0,
+        "tolerance": 0.001
+      }
     }
   ]
 }

--- a/ManufacturingOptimization.ProviderSimulator/Settings/EngineeringDesignFirmSettings.cs
+++ b/ManufacturingOptimization.ProviderSimulator/Settings/EngineeringDesignFirmSettings.cs
@@ -1,8 +1,9 @@
 namespace ManufacturingOptimization.ProviderSimulator.Settings;
 
 /// <summary>
-/// Settings for Engineering Design Firm provider.
+/// Settings for Engineering Design Firm provider (TP2).
 /// Configure via environment variables: EngineeringDesignFirm__ProviderId, EngineeringDesignFirm__ProviderName
+/// Capabilities: Redesign
 /// </summary>
 public class EngineeringDesignFirmSettings
 {
@@ -10,4 +11,9 @@ public class EngineeringDesignFirmSettings
     
     public string ProviderId { get; set; } = string.Empty;
     public string ProviderName { get; set; } = string.Empty;
+    
+    public List<string> Capabilities { get; set; } = new();
+    public double AxisHeight { get; set; } = 0.0;
+    public double Power { get; set; } = 0.0;
+    public double Tolerance { get; set; } = 0.0;
 }

--- a/ManufacturingOptimization.ProviderSimulator/Settings/MainRemanufacturingCenterSettings.cs
+++ b/ManufacturingOptimization.ProviderSimulator/Settings/MainRemanufacturingCenterSettings.cs
@@ -1,8 +1,9 @@
 namespace ManufacturingOptimization.ProviderSimulator.Settings;
 
 /// <summary>
-/// Settings for Main Remanufacturing Center provider.
+/// Settings for Main Remanufacturing Center provider (TP1).
 /// Configure via environment variables: MainRemanufacturingCenter__ProviderId, MainRemanufacturingCenter__ProviderName
+/// Capabilities: Cleaning, Disassembly, PartSub, Reassembly, Certification
 /// </summary>
 public class MainRemanufacturingCenterSettings
 {
@@ -10,4 +11,9 @@ public class MainRemanufacturingCenterSettings
     
     public string ProviderId { get; set; } = string.Empty;
     public string ProviderName { get; set; } = string.Empty;
+    
+    public List<string> Capabilities { get; set; } = new();
+    public double AxisHeight { get; set; } = 0.0;
+    public double Power { get; set; } = 0.0;
+    public double Tolerance { get; set; } = 0.0;
 }

--- a/ManufacturingOptimization.ProviderSimulator/Settings/PrecisionMachineShopSettings.cs
+++ b/ManufacturingOptimization.ProviderSimulator/Settings/PrecisionMachineShopSettings.cs
@@ -1,8 +1,9 @@
 namespace ManufacturingOptimization.ProviderSimulator.Settings;
 
 /// <summary>
-/// Settings for Precision Machine Shop provider.
+/// Settings for Precision Machine Shop provider (TP3).
 /// Configure via environment variables: PrecisionMachineShop__ProviderId, PrecisionMachineShop__ProviderName
+/// Capabilities: Turning, Grinding
 /// </summary>
 public class PrecisionMachineShopSettings
 {
@@ -10,4 +11,9 @@ public class PrecisionMachineShopSettings
     
     public string ProviderId { get; set; } = string.Empty;
     public string ProviderName { get; set; } = string.Empty;
+    
+    public List<string> Capabilities { get; set; } = new();
+    public double AxisHeight { get; set; } = 0.0;
+    public double Power { get; set; } = 0.0;
+    public double Tolerance { get; set; } = 0.0;
 }

--- a/ManufacturingOptimization.ProviderSimulator/TechnologyProviders/EngineeringDesignFirm.cs
+++ b/ManufacturingOptimization.ProviderSimulator/TechnologyProviders/EngineeringDesignFirm.cs
@@ -9,17 +9,32 @@ public class EngineeringDesignFirm : IProviderSimulator
 {
     private readonly ILogger<EngineeringDesignFirm> _logger;
     private readonly Random _random = new();
+    private readonly EngineeringDesignFirmSettings _settings;
 
     public Guid ProviderId { get; }
     public string ProviderName { get; }
+    public List<string> Capabilities { get; }
+    public double AxisHeight { get; }
+    public double Power { get; }
+    public double Tolerance { get; }
 
     public EngineeringDesignFirm(
         ILogger<EngineeringDesignFirm> logger,
         IOptions<EngineeringDesignFirmSettings> settings)
     {
         _logger = logger;
-        ProviderId = Guid.Parse(settings.Value.ProviderId);
-        ProviderName = settings.Value.ProviderName;
+        _settings = settings.Value;
+        
+        ProviderId = Guid.Parse(_settings.ProviderId);
+        ProviderName = _settings.ProviderName;
+        Capabilities = _settings.Capabilities;
+        AxisHeight = _settings.AxisHeight;
+        Power = _settings.Power;
+        Tolerance = _settings.Tolerance;
+        
+        _logger.LogInformation(
+            "EngineeringDesignFirm initialized: {ProviderId}, {ProviderName}, Capabilities: [{Capabilities}], AxisHeight: {AxisHeight}, Power: {Power}, Tolerance: {Tolerance}",
+            ProviderId, ProviderName, string.Join(", ", Capabilities), AxisHeight, Power, Tolerance);
     }
 
     public bool HandleProposal(ProposeProcessCommand proposal)

--- a/ManufacturingOptimization.ProviderSimulator/TechnologyProviders/MainRemanufacturingCenter.cs
+++ b/ManufacturingOptimization.ProviderSimulator/TechnologyProviders/MainRemanufacturingCenter.cs
@@ -9,17 +9,32 @@ public class MainRemanufacturingCenter : IProviderSimulator
 {
     private readonly ILogger<MainRemanufacturingCenter> _logger;
     private readonly Random _random = new();
+    private readonly MainRemanufacturingCenterSettings _settings;
 
     public Guid ProviderId { get; }
     public string ProviderName { get; }
+    public List<string> Capabilities { get; }
+    public double AxisHeight { get; }
+    public double Power { get; }
+    public double Tolerance { get; }
 
     public MainRemanufacturingCenter(
         ILogger<MainRemanufacturingCenter> logger,
         IOptions<MainRemanufacturingCenterSettings> settings)
     {
         _logger = logger;
-        ProviderId = Guid.Parse(settings.Value.ProviderId);
-        ProviderName = settings.Value.ProviderName;
+        _settings = settings.Value;
+        
+        ProviderId = Guid.Parse(_settings.ProviderId);
+        ProviderName = _settings.ProviderName;
+        Capabilities = _settings.Capabilities;
+        AxisHeight = _settings.AxisHeight;
+        Power = _settings.Power;
+        Tolerance = _settings.Tolerance;
+        
+        _logger.LogInformation(
+            "MainRemanufacturingCenter initialized: {ProviderId}, {ProviderName}, Capabilities: [{Capabilities}], AxisHeight: {AxisHeight}, Power: {Power}, Tolerance: {Tolerance}",
+            ProviderId, ProviderName, string.Join(", ", Capabilities), AxisHeight, Power, Tolerance);
     }
 
     public bool HandleProposal(ProposeProcessCommand proposal)

--- a/ManufacturingOptimization.ProviderSimulator/TechnologyProviders/PrecisionMachineShop.cs
+++ b/ManufacturingOptimization.ProviderSimulator/TechnologyProviders/PrecisionMachineShop.cs
@@ -9,17 +9,28 @@ public class PrecisionMachineShop : IProviderSimulator
 {
     private readonly ILogger<PrecisionMachineShop> _logger;
     private readonly Random _random = new();
+    private readonly PrecisionMachineShopSettings _settings;
 
     public Guid ProviderId { get; }
     public string ProviderName { get; }
+    public List<string> Capabilities { get; }
+    public double AxisHeight { get; }
+    public double Power { get; }
+    public double Tolerance { get; }
 
     public PrecisionMachineShop(
         ILogger<PrecisionMachineShop> logger,
         IOptions<PrecisionMachineShopSettings> settings)
     {
         _logger = logger;
-        ProviderId = Guid.Parse(settings.Value.ProviderId);
-        ProviderName = settings.Value.ProviderName;
+        _settings = settings.Value;
+        
+        ProviderId = Guid.Parse(_settings.ProviderId);
+        ProviderName = _settings.ProviderName;
+        Capabilities = _settings.Capabilities;
+        AxisHeight = _settings.AxisHeight;
+        Power = _settings.Power;
+        Tolerance = _settings.Tolerance;
     }
 
     public bool HandleProposal(ProposeProcessCommand proposal)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -18,6 +18,14 @@ services:
       - PROVIDER_TYPE=MainRemanufacturingCenter
       - MainRemanufacturingCenter__ProviderId=f93a2956-e430-4b50-b688-991b5c33f5f4
       - MainRemanufacturingCenter__ProviderName=Main Remanufacturing Center
+      - MainRemanufacturingCenter__Capabilities__0=Cleaning
+      - MainRemanufacturingCenter__Capabilities__1=Disassembly
+      - MainRemanufacturingCenter__Capabilities__2=PartSub
+      - MainRemanufacturingCenter__Capabilities__3=Reassembly
+      - MainRemanufacturingCenter__Capabilities__4=Certification
+      - MainRemanufacturingCenter__AxisHeight=500.0
+      - MainRemanufacturingCenter__Power=1500.0
+      - MainRemanufacturingCenter__Tolerance=0.01
       - RabbitMQ__Host=rabbitmq
       - RabbitMQ__Port=5672
       - RabbitMQ__Username=admin
@@ -40,6 +48,10 @@ services:
       - PROVIDER_TYPE=EngineeringDesignFirm
       - EngineeringDesignFirm__ProviderId=f8127a26-e818-4d27-8812-10d422c45a6c
       - EngineeringDesignFirm__ProviderName=Engineering Design Firm
+      - EngineeringDesignFirm__Capabilities__0=Redesign
+      - EngineeringDesignFirm__AxisHeight=0.0
+      - EngineeringDesignFirm__Power=0.0
+      - EngineeringDesignFirm__Tolerance=0.001
       - RabbitMQ__Host=rabbitmq
       - RabbitMQ__Port=5672
       - RabbitMQ__Username=admin
@@ -62,6 +74,11 @@ services:
       - PROVIDER_TYPE=PrecisionMachineShop
       - PrecisionMachineShop__ProviderId=70564b7f-d634-4a90-b3f9-33224915dbc4
       - PrecisionMachineShop__ProviderName=Precision Machine Shop
+      - PrecisionMachineShop__Capabilities__0=Turning
+      - PrecisionMachineShop__Capabilities__1=Grinding
+      - PrecisionMachineShop__AxisHeight=300.0
+      - PrecisionMachineShop__Power=2000.0
+      - PrecisionMachineShop__Tolerance=0.001
       - RabbitMQ__Host=rabbitmq
       - RabbitMQ__Port=5672
       - RabbitMQ__Username=admin


### PR DESCRIPTION
# US-11: Validate Provider Capabilities Before Startup

## Summary
Implements capability and technical requirements validation for technology providers before registration. Only validated providers are started and added to the system.

## Validation Flow
1. ProviderRegistry loads providers from `providers.json`
2. Sends `ValidateProviderCapabilityCommand` to Engine
3. Engine validates capabilities and technical limits
4. Engine responds with Approved/Declined event
5. Registry starts only approved providers
6. Publishes `AllProvidersReady` when complete

## Validation Rules
**Required Capabilities:**
- TP1 (MainRemanufacturingCenter): Cleaning, Disassembly, PartSubstitution, Reassembly, Certification
- TP2 (EngineeringDesignFirm): Redesign
- TP3 (PrecisionMachineShop): Turning, Grinding

**Technical Limits:** AxisHeight (100-1000), Power (500-5000), Tolerance (0.001-0.1)

## Key Changes
- **RabbitMqService**: Fixed consumer competition by reusing consumers per queue + MessageType headers
- **Provider entity**: Added Capabilities and TechnicalRequirements fields
- **Queue management**: Added PurgeQueue to clear stale messages on startup
- **Configuration**: Validation rules in Engine appsettings.json
- **Docker**: Pass capabilities/requirements via environment variables

## Bug Fixes
- Fixed "PartSub" → "PartSubstitution" in providers.json
- Constructor-based RabbitMQ setup to prevent race conditions
- RebbitMqService multiple consumers per queue