### PR TITLE
US-24-T2: Track performance metrics for each provider

### DIFF
--- a/ManufacturingOptimization.Analytics/AnalyticsStore.cs
+++ b/ManufacturingOptimization.Analytics/AnalyticsStore.cs
@@ -1,0 +1,40 @@
+using ManufacturingOptimization.Common.Messaging.Messages.PlanManagment;
+using System.Collections.Concurrent;
+
+namespace ManufacturingOptimization.Analytics.Services;
+
+public interface IAnalyticsStore
+{
+    void RecordSelection(SelectStrategyCommand selection);
+    AnalyticsSummary GetSummary();
+}
+
+public class InMemoryAnalyticsStore : IAnalyticsStore
+{
+    // Thread-safe collection to hold the history in memory
+    private readonly ConcurrentBag<SelectStrategyCommand> _history = new();
+
+    public void RecordSelection(SelectStrategyCommand selection)
+    {
+        _history.Add(selection);
+    }
+
+    public AnalyticsSummary GetSummary()
+    {
+        return new AnalyticsSummary
+        {
+            TotalDeals = _history.Count,
+            TopProvider = _history
+                .GroupBy(x => x.SelectedProviderId)
+                .OrderByDescending(g => g.Count())
+                .Select(g => g.Key)
+                .FirstOrDefault() ?? "None"
+        };
+    }
+}
+
+public class AnalyticsSummary
+{
+    public int TotalDeals { get; set; }
+    public string TopProvider { get; set; } = string.Empty;
+}

--- a/ManufacturingOptimization.Analytics/AnalyticsWorker.cs
+++ b/ManufacturingOptimization.Analytics/AnalyticsWorker.cs
@@ -1,0 +1,37 @@
+using ManufacturingOptimization.Common.Messaging.Abstractions;
+// FIX: Use the existing namespace
+using ManufacturingOptimization.Common.Messaging.Messages.PlanManagment; 
+
+namespace ManufacturingOptimization.Analytics;
+
+public class AnalyticsWorker : BackgroundService
+{
+    private readonly ILogger<AnalyticsWorker> _logger;
+    private readonly IMessageSubscriber _subscriber;
+
+    public AnalyticsWorker(ILogger<AnalyticsWorker> logger, IMessageSubscriber subscriber)
+    {
+        _logger = logger;
+        _subscriber = subscriber;
+    }
+
+    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Analytics Worker started. Waiting for data...");
+
+        _subscriber.Subscribe<SelectStrategyCommand>("analytics.strategy.selected", HandleStrategySelected);
+
+        return Task.CompletedTask;
+    }
+
+    private void HandleStrategySelected(SelectStrategyCommand message)
+    {
+        _logger.LogInformation("--- 📊 NEW DATA POINT RECEIVED ---");
+        _logger.LogInformation($"Request ID:   {message.RequestId}");
+        // Note: The existing class might use 'SelectedProviderId' instead of 'ProviderId'
+        // Let's check the property names in the next step if this fails.
+        _logger.LogInformation($"Winner:       {message.SelectedProviderId}"); 
+        _logger.LogInformation($"Strategy:     {message.SelectedStrategyName}");
+        _logger.LogInformation("----------------------------------");
+    }
+}

--- a/ManufacturingOptimization.Analytics/AnalyticsWorker.cs
+++ b/ManufacturingOptimization.Analytics/AnalyticsWorker.cs
@@ -1,6 +1,6 @@
+using ManufacturingOptimization.Analytics.Services;
 using ManufacturingOptimization.Common.Messaging.Abstractions;
-// FIX: Use the existing namespace
-using ManufacturingOptimization.Common.Messaging.Messages.PlanManagment; 
+using ManufacturingOptimization.Common.Messaging.Messages.PlanManagment;
 
 namespace ManufacturingOptimization.Analytics;
 
@@ -8,18 +8,32 @@ public class AnalyticsWorker : BackgroundService
 {
     private readonly ILogger<AnalyticsWorker> _logger;
     private readonly IMessageSubscriber _subscriber;
+    private readonly IMessagingInfrastructure _infra; // <--- 1. Add this
+    private readonly IAnalyticsStore _store;
 
-    public AnalyticsWorker(ILogger<AnalyticsWorker> logger, IMessageSubscriber subscriber)
+    public AnalyticsWorker(
+        ILogger<AnalyticsWorker> logger, 
+        IMessageSubscriber subscriber,
+        IMessagingInfrastructure infra, // <--- 2. Inject this
+        IAnalyticsStore store)
     {
         _logger = logger;
         _subscriber = subscriber;
+        _infra = infra; // <--- 3. Assign this
+        _store = store;
     }
 
     protected override Task ExecuteAsync(CancellationToken stoppingToken)
     {
         _logger.LogInformation("Analytics Worker started. Waiting for data...");
 
+        // Subscribe to the queue
         _subscriber.Subscribe<SelectStrategyCommand>("analytics.strategy.selected", HandleStrategySelected);
+
+        // --- 4. ADD THIS BINDING ---
+        // This connects your queue to the "optimization.exchange" so you get the messages!
+        _infra.BindQueue("analytics.strategy.selected", "optimization.exchange", "optimization.strategy.selected");
+        // ----------------------------
 
         return Task.CompletedTask;
     }
@@ -27,11 +41,10 @@ public class AnalyticsWorker : BackgroundService
     private void HandleStrategySelected(SelectStrategyCommand message)
     {
         _logger.LogInformation("--- 📊 NEW DATA POINT RECEIVED ---");
-        _logger.LogInformation($"Request ID:   {message.RequestId}");
-        // Note: The existing class might use 'SelectedProviderId' instead of 'ProviderId'
-        // Let's check the property names in the next step if this fails.
-        _logger.LogInformation($"Winner:       {message.SelectedProviderId}"); 
-        _logger.LogInformation($"Strategy:     {message.SelectedStrategyName}");
-        _logger.LogInformation("----------------------------------");
+        
+        _store.RecordSelection(message);
+        
+        var summary = _store.GetSummary();
+        _logger.LogInformation($"Total Deals: {summary.TotalDeals} | Top Provider: {summary.TopProvider}");
     }
 }

--- a/ManufacturingOptimization.Analytics/Dockerfile
+++ b/ManufacturingOptimization.Analytics/Dockerfile
@@ -1,0 +1,37 @@
+# Base runtime image
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
+WORKDIR /app
+EXPOSE 80
+
+# Build stage
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+WORKDIR /src
+
+# Copy Solution and Project files
+COPY ["ManufacturingOptimization.sln", "./"]
+COPY ["ManufacturingOptimization.Analytics/ManufacturingOptimization.Analytics.csproj", "ManufacturingOptimization.Analytics/"]
+COPY ["ManufacturingOptimization.Common.Models/ManufacturingOptimization.Common.Models.csproj", "ManufacturingOptimization.Common.Models/"]
+COPY ["ManufacturingOptimization.Common.Messaging/ManufacturingOptimization.Common.Messaging.csproj", "ManufacturingOptimization.Common.Messaging/"]
+COPY ["ManufacturingOptimization.Engine/ManufacturingOptimization.Engine.csproj", "ManufacturingOptimization.Engine/"]
+COPY ["ManufacturingOptimization.ProviderRegistry/ManufacturingOptimization.ProviderRegistry.csproj", "ManufacturingOptimization.ProviderRegistry/"]
+COPY ["ManufacturingOptimization.Gateway/ManufacturingOptimization.Gateway.csproj", "ManufacturingOptimization.Gateway/"]
+
+# Restore dependencies
+RUN dotnet restore "ManufacturingOptimization.Analytics/ManufacturingOptimization.Analytics.csproj"
+
+# Copy the rest of the source code
+COPY . .
+
+# Build the project
+WORKDIR "/src/ManufacturingOptimization.Analytics"
+RUN dotnet build "ManufacturingOptimization.Analytics.csproj" -c Release -o /app/build
+
+# Publish stage
+FROM build AS publish
+RUN dotnet publish "ManufacturingOptimization.Analytics.csproj" -c Release -o /app/publish /p:UseAppHost=false
+
+# Final runtime image
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "ManufacturingOptimization.Analytics.dll"]

--- a/ManufacturingOptimization.Analytics/ManufacturingOptimization.Analytics.csproj
+++ b/ManufacturingOptimization.Analytics/ManufacturingOptimization.Analytics.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <ItemGroup>
+    <ProjectReference Include="..\ManufacturingOptimization.Common.Models\ManufacturingOptimization.Common.Models.csproj" />
+    <ProjectReference Include="..\ManufacturingOptimization.Common.Messaging\ManufacturingOptimization.Common.Messaging.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/ManufacturingOptimization.Analytics/Program.cs
+++ b/ManufacturingOptimization.Analytics/Program.cs
@@ -1,21 +1,23 @@
-using ManufacturingOptimization.Analytics; // This namespace now exists!
+using ManufacturingOptimization.Analytics;
+using ManufacturingOptimization.Analytics.Services;
 using ManufacturingOptimization.Common.Messaging;
 using ManufacturingOptimization.Common.Messaging.Abstractions;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// 1. Configure RabbitMQ Settings
 builder.Services.Configure<RabbitMqSettings>(builder.Configuration.GetSection(RabbitMqSettings.SectionName));
-
-// 2. Register RabbitMQ Service
 builder.Services.AddSingleton<RabbitMqService>();
+
+// Existing Subscriber
 builder.Services.AddSingleton<IMessageSubscriber>(sp => sp.GetRequiredService<RabbitMqService>());
 
-// 3. Register the Background Worker
+// Allows us to Bind Queues manually
+builder.Services.AddSingleton<IMessagingInfrastructure>(sp => sp.GetRequiredService<RabbitMqService>());
+// --------------------
+
+builder.Services.AddSingleton<IAnalyticsStore, InMemoryAnalyticsStore>();
 builder.Services.AddHostedService<AnalyticsWorker>(); 
 
 var app = builder.Build();
-
 app.MapGet("/", () => "Analytics Service is Running 📊");
-
 app.Run();

--- a/ManufacturingOptimization.Analytics/Program.cs
+++ b/ManufacturingOptimization.Analytics/Program.cs
@@ -1,0 +1,21 @@
+using ManufacturingOptimization.Analytics; // This namespace now exists!
+using ManufacturingOptimization.Common.Messaging;
+using ManufacturingOptimization.Common.Messaging.Abstractions;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// 1. Configure RabbitMQ Settings
+builder.Services.Configure<RabbitMqSettings>(builder.Configuration.GetSection(RabbitMqSettings.SectionName));
+
+// 2. Register RabbitMQ Service
+builder.Services.AddSingleton<RabbitMqService>();
+builder.Services.AddSingleton<IMessageSubscriber>(sp => sp.GetRequiredService<RabbitMqService>());
+
+// 3. Register the Background Worker
+builder.Services.AddHostedService<AnalyticsWorker>(); 
+
+var app = builder.Build();
+
+app.MapGet("/", () => "Analytics Service is Running 📊");
+
+app.Run();

--- a/ManufacturingOptimization.Analytics/Properties/launchSettings.json
+++ b/ManufacturingOptimization.Analytics/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5113",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7188;http://localhost:5113",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/ManufacturingOptimization.Analytics/appsettings.Development.json
+++ b/ManufacturingOptimization.Analytics/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/ManufacturingOptimization.Analytics/appsettings.json
+++ b/ManufacturingOptimization.Analytics/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,6 +99,21 @@ services:
       - manufacturing-network
     restart: unless-stopped
 
+  analytics:
+    image: manufacturing-analytics
+    build:
+      context: .
+      dockerfile: ManufacturingOptimization.Analytics/Dockerfile
+    environment:
+      - RabbitMQ__Host=rabbitmq
+      - RabbitMQ__Port=5672
+      - RabbitMQ__Username=admin
+      - RabbitMQ__Password=admin123
+    depends_on:
+      - rabbitmq
+    networks:
+      - manufacturing-network
+
   # Providers are started automatically through provider-registry
   # ProviderRegistry creates Docker containers via Docker API
 


### PR DESCRIPTION
Description: This PR extends the Analytics Service to persist data in memory, allowing for real-time tracking of provider performance metrics (e.g., total deals won).

Changes:

In-Memory Store: Implemented InMemoryAnalyticsStore using a thread-safe collection to hold strategy selection history.

Worker Update: Modified AnalyticsWorker to save incoming messages to the store instead of just logging them.

Metrics Calculation: Added logic to calculate "Total Deals" and identify the "Top Provider" dynamically based on stored history.

Dependency Injection: Registered the store as a Singleton to ensure data persists across the application lifespan.

Verification:

Run docker compose up -d --build.

Send multiple POST /api/optimization/select requests via Swagger.

Check logs: docker compose logs -f analytics.

Expected: The log should show an increasing count (e.g., Total Deals: 1, Total Deals: 2).

Closes: #301 (US-24-T2)