### PR TITLE
Centralize RabbitMQ exchange creation

### DIFF
--- a/ManufacturingOptimization.Common.Messaging/RabbitMqService.cs
+++ b/ManufacturingOptimization.Common.Messaging/RabbitMqService.cs
@@ -52,7 +52,22 @@ public class RabbitMqService : IMessagePublisher, IMessageSubscriber, IMessaging
                 exchange: Exchanges.Optimization,
                 type: ExchangeType.Topic,
                 durable: true);
-            
+
+            _channel.ExchangeDeclare(
+                exchange: Exchanges.System,
+                type: ExchangeType.Topic,
+                durable: true);
+
+            _channel.ExchangeDeclare(
+                exchange: Exchanges.Provider,
+                type: ExchangeType.Topic,
+                durable: true);
+
+            _channel.ExchangeDeclare(
+                exchange: Exchanges.Process,
+                type: ExchangeType.Topic,
+                durable: true);
+
             // Setup reply queue for RPC pattern
             _replyQueueName = _channel.QueueDeclare().QueueName;
             SetupReplyQueueConsumer();

--- a/ManufacturingOptimization.Engine/EngineWorker.cs
+++ b/ManufacturingOptimization.Engine/EngineWorker.cs
@@ -49,7 +49,7 @@ public class EngineWorker : BackgroundService
     private void SetupRabbitMq()
     {
         // Provider events
-        _messagingInfrastructure.DeclareExchange(Exchanges.Provider);
+        //_messagingInfrastructure.DeclareExchange(Exchanges.Provider);
         _messagingInfrastructure.DeclareQueue("engine.provider.events");
         _messagingInfrastructure.BindQueue("engine.provider.events", Exchanges.Provider, ProviderRoutingKeys.Registered);
         _messagingInfrastructure.BindQueue("engine.provider.events", Exchanges.Provider, ProviderRoutingKeys.AllRegistered);

--- a/ManufacturingOptimization.Engine/Services/StartupCoordinator.cs
+++ b/ManufacturingOptimization.Engine/Services/StartupCoordinator.cs
@@ -43,7 +43,7 @@ public class StartupCoordinator : SystemReadinessService
         base.SetupRabbitMq();
         
         // Additionally, listen for service ready events to coordinate startup
-        _messagingInfrastructure.DeclareExchange(Exchanges.System);
+        //_messagingInfrastructure.DeclareExchange(Exchanges.System);
         _messagingInfrastructure.DeclareQueue("coordinator.service.ready");
         _messagingInfrastructure.BindQueue("coordinator.service.ready", Exchanges.System, SystemRoutingKeys.ServiceReady);
         _messagingInfrastructure.PurgeQueue("coordinator.service.ready");

--- a/ManufacturingOptimization.Gateway/GatewayWorker.cs
+++ b/ManufacturingOptimization.Gateway/GatewayWorker.cs
@@ -49,13 +49,13 @@ public class GatewayWorker : BackgroundService
     private void SetupRabbitMq()
     {
         // Listen to provider registrations
-        _messagingInfrastructure.DeclareExchange(Exchanges.Provider);
+        //_messagingInfrastructure.DeclareExchange(Exchanges.Provider);
         _messagingInfrastructure.DeclareQueue("gateway.provider.events");
         _messagingInfrastructure.BindQueue("gateway.provider.events", Exchanges.Provider, ProviderRoutingKeys.Registered);
         _messagingInfrastructure.PurgeQueue("gateway.provider.events");
 
         // Listen to optimization responses
-        _messagingInfrastructure.DeclareExchange(Exchanges.Optimization);
+        //_messagingInfrastructure.DeclareExchange(Exchanges.Optimization);
         _messagingInfrastructure.DeclareQueue("gateway.optimization.responses");
         _messagingInfrastructure.BindQueue("gateway.optimization.responses", Exchanges.Optimization, OptimizationRoutingKeys.PlanReady);
         _messagingInfrastructure.PurgeQueue("gateway.optimization.responses");

--- a/ManufacturingOptimization.ProviderRegistry/ProviderRegistryWorker.cs
+++ b/ManufacturingOptimization.ProviderRegistry/ProviderRegistryWorker.cs
@@ -65,7 +65,7 @@ public class ProviderRegistryWorker : BackgroundService
 
     private void SetupRabbitMq()
     {
-        _messagingInfrastructure.DeclareExchange(Exchanges.Provider);
-        _messagingInfrastructure.DeclareExchange(Exchanges.System);
+        //_messagingInfrastructure.DeclareExchange(Exchanges.Provider);
+        //_messagingInfrastructure.DeclareExchange(Exchanges.System);
     }
 }

--- a/ManufacturingOptimization.ProviderSimulator/ProviderSimulatorWorker.cs
+++ b/ManufacturingOptimization.ProviderSimulator/ProviderSimulatorWorker.cs
@@ -38,7 +38,7 @@ public class ProviderSimulatorWorker : BackgroundService
     private void SetupRabbitMq()
     {
         // Listen to proposals from Engine
-        _messagingInfrastructure.DeclareExchange(Exchanges.Process);
+        //_messagingInfrastructure.DeclareExchange(Exchanges.Process);
         
         // Listen to process proposals for this specific provider
         var proposalQueueName = $"process.proposal.{_providerLogic.Provider.Id}";
@@ -62,6 +62,6 @@ public class ProviderSimulatorWorker : BackgroundService
         _messageSubscriber.Subscribe<RequestProvidersRegistrationCommand>(providerCoordinationQueue, e => _dispatcher.DispatchAsync(e));
 
         // Setup for provider registration
-        _messagingInfrastructure.DeclareExchange(Exchanges.Provider);
+        //_messagingInfrastructure.DeclareExchange(Exchanges.Provider);
     }
 }


### PR DESCRIPTION
This PR refactors the messaging infrastructure so that all required RabbitMQ exchanges are declared in RabbitMqService. Previously, exchanges were declared in multiple places across different services, which could lead to race conditions and AMQP 404 errors if an exchange was missing or declared inconsistently.